### PR TITLE
Foundation for using future backends

### DIFF
--- a/architecture/mock_priority_queue.go
+++ b/architecture/mock_priority_queue.go
@@ -62,7 +62,7 @@ func (_m *MockPriorityQueue) Find(id string) PriorityQueueItem {
 }
 
 // Init provides a mock function with given fields:
-func (_m *MockPriorityQueue) Init() {
+func (_m *MockPriorityQueue) Init(tubeName string) {
 	_m.Called()
 }
 

--- a/architecture/tube.go
+++ b/architecture/tube.go
@@ -2,9 +2,10 @@ package architecture
 
 import (
 	"errors"
-	"github.com/op/go-logging"
-	"time"
 	"strconv"
+	"time"
+
+	"github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("BEANSTALKG")
@@ -14,7 +15,7 @@ const MAX_JOBS_PER_ITERATION int = 20                       // maximum number of
 
 // PriorityQueue is the interface that all backends should implement, See backend/min_heap.go for an example
 type PriorityQueue interface {
-	Init()
+	Init(tubeName string)
 	// queue item
 	Enqueue(item PriorityQueueItem)
 	// get the highest priority item without removing
@@ -62,11 +63,11 @@ func NewTube(name string, priorityQueueCreator PriorityQueueCreator) *Tube {
 		awaitingClients:      priorityQueueCreator(),
 		awaitingTimedClients: make(map[string]*AwaitingClient),
 	}
-	tube.ready.Init()
-	tube.delayed.Init()
-	tube.reserved.Init()
-	tube.buried.Init()
-	tube.awaitingClients.Init()
+	tube.ready.Init(name)
+	tube.delayed.Init(name)
+	tube.reserved.Init(name)
+	tube.buried.Init(name)
+	tube.awaitingClients.Init(name)
 	return tube
 }
 

--- a/backend/backends.go
+++ b/backend/backends.go
@@ -1,0 +1,23 @@
+package backend
+
+import (
+	"github.com/beanstalkg/beanstalkg/architecture"
+)
+
+const defaultBackend = "minheap"
+
+var validBackends map[string]architecture.PriorityQueueCreator = map[string]architecture.PriorityQueueCreator{
+	"minheap": func() architecture.PriorityQueue { return &MinHeap{} },
+}
+
+// QueueCreator retrieves the PriorityQueueCreator that returns a
+// PriorityQueue for the specified backend.  Falls back to
+// defaultBackend if the requested backend is invalid.
+func QueueCreator(backend string) architecture.PriorityQueueCreator {
+	if _, ok := validBackends[backend]; !ok {
+		log.Debugf("%s backend not supported, falling back to %s.", backend, defaultBackend)
+		backend = defaultBackend
+	}
+
+	return validBackends[backend]
+}

--- a/backend/min_heap.go
+++ b/backend/min_heap.go
@@ -12,11 +12,14 @@ var log = logging.MustGetLogger("BEANSTALKG")
 
 type MinHeap struct {
 	Store []architecture.PriorityQueueItem
+
+	tubeName string
 }
 
 // +++++++++++++ START - PriorityQueue Interface methods +++++++++++++++++
 
-func (h *MinHeap) Init() {
+func (h *MinHeap) Init(tubeName string) {
+	h.tubeName = tubeName
 	//for i := 0; i < 100000; i++ {
 	//	h.Store[i] = 1000000001
 	//}

--- a/config.go
+++ b/config.go
@@ -3,12 +3,23 @@ package main
 import (
 	"flag"
 
+	"github.com/beanstalkg/beanstalkg/architecture"
+	"github.com/beanstalkg/beanstalkg/backend"
 	"github.com/jinzhu/configor"
 )
 
 type ServerConfig struct {
-	Port  string `default:"11300"`
-	Debug bool
+	Port    string `default:"11300"`
+	Debug   bool
+	Backend string `default:"minheap"`
+
+	queueCreator architecture.PriorityQueueCreator
+}
+
+const defaultBackend = "minheap"
+
+var validBackends map[string]architecture.PriorityQueueCreator = map[string]architecture.PriorityQueueCreator{
+	"minheap": func() architecture.PriorityQueue { return &backend.MinHeap{} },
 }
 
 // getConfig sets values based on the following order of precedence:
@@ -21,6 +32,14 @@ func getConfig() *ServerConfig {
 	flag.StringVar(&cfg.Port, "port", cfg.Port, "Port for beanstalkg server")
 	flag.BoolVar(&cfg.Debug, "debug", cfg.Debug, "Start server in debug mode. Logs shall contain more information")
 	flag.Parse()
+
+	// Fallback to default backend if the provided one is invalid.
+	// This guarantees that the server will start.
+	if _, ok := validBackends[cfg.Backend]; !ok {
+		log.Debugf("%s backend not supported, falling back to %s.", cfg.Backend, defaultBackend)
+		cfg.Backend = defaultBackend
+	}
+	cfg.queueCreator = validBackends[cfg.Backend]
 
 	return cfg
 }

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ func getConfig() *ServerConfig {
 	configor.New(&configor.Config{ENVPrefix: "BEANSTALKG"}).Load(cfg, "config.yml")
 
 	flag.StringVar(&cfg.Port, "port", cfg.Port, "Port for beanstalkg server")
+	flag.StringVar(&cfg.Backend, "backend", cfg.Backend, "Use this backend for job storage.")
 	flag.BoolVar(&cfg.Debug, "debug", cfg.Debug, "Start server in debug mode. Logs shall contain more information")
 	flag.Parse()
 

--- a/config.go
+++ b/config.go
@@ -3,8 +3,6 @@ package main
 import (
 	"flag"
 
-	"github.com/beanstalkg/beanstalkg/architecture"
-	"github.com/beanstalkg/beanstalkg/backend"
 	"github.com/jinzhu/configor"
 )
 
@@ -12,14 +10,6 @@ type ServerConfig struct {
 	Port    string `default:"11300"`
 	Debug   bool
 	Backend string `default:"minheap"`
-
-	queueCreator architecture.PriorityQueueCreator
-}
-
-const defaultBackend = "minheap"
-
-var validBackends map[string]architecture.PriorityQueueCreator = map[string]architecture.PriorityQueueCreator{
-	"minheap": func() architecture.PriorityQueue { return &backend.MinHeap{} },
 }
 
 // getConfig sets values based on the following order of precedence:
@@ -32,14 +22,6 @@ func getConfig() *ServerConfig {
 	flag.StringVar(&cfg.Port, "port", cfg.Port, "Port for beanstalkg server")
 	flag.BoolVar(&cfg.Debug, "debug", cfg.Debug, "Start server in debug mode. Logs shall contain more information")
 	flag.Parse()
-
-	// Fallback to default backend if the provided one is invalid.
-	// This guarantees that the server will start.
-	if _, ok := validBackends[cfg.Backend]; !ok {
-		log.Debugf("%s backend not supported, falling back to %s.", cfg.Backend, defaultBackend)
-		cfg.Backend = defaultBackend
-	}
-	cfg.queueCreator = validBackends[cfg.Backend]
 
 	return cfg
 }

--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,3 @@
 port: 11300
 debug: false
+backend: minheap

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/beanstalkg/beanstalkg/architecture"
+	"github.com/beanstalkg/beanstalkg/backend"
 	"github.com/beanstalkg/beanstalkg/operation"
 	"github.com/op/go-logging"
 )
@@ -31,7 +32,7 @@ func main() {
 	// use this tube to send the channels for each individual tube to the clients when the do 'use' command
 	useTubeConnectionReceiver := make(chan chan architecture.Command)
 	watchedTubeConnectionsReceiver := make(chan chan architecture.Command)
-	operation.NewTubeRegister(tubeRegister, useTubeConnectionReceiver, watchedTubeConnectionsReceiver, stop, cfg.queueCreator)
+	operation.NewTubeRegister(tubeRegister, useTubeConnectionReceiver, watchedTubeConnectionsReceiver, stop, backend.QueueCreator(cfg.Backend))
 	log.Info("BEANSTALKG listening on: ", cfg.Port)
 
 	for {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	// use this tube to send the channels for each individual tube to the clients when the do 'use' command
 	useTubeConnectionReceiver := make(chan chan architecture.Command)
 	watchedTubeConnectionsReceiver := make(chan chan architecture.Command)
-	operation.NewTubeRegister(tubeRegister, useTubeConnectionReceiver, watchedTubeConnectionsReceiver, stop)
+	operation.NewTubeRegister(tubeRegister, useTubeConnectionReceiver, watchedTubeConnectionsReceiver, stop, cfg.queueCreator)
 	log.Info("BEANSTALKG listening on: ", cfg.Port)
 
 	for {

--- a/operation/tube_handler.go
+++ b/operation/tube_handler.go
@@ -1,9 +1,9 @@
 package operation
 
 import (
-	"github.com/beanstalkg/beanstalkg/architecture"
-	"github.com/beanstalkg/beanstalkg/backend"
 	"time"
+
+	"github.com/beanstalkg/beanstalkg/architecture"
 )
 
 func NewTubeHandler(
@@ -11,13 +11,11 @@ func NewTubeHandler(
 	commands chan architecture.Command,
 	watchedTubeConnectionsReceiver chan chan architecture.Command,
 	stop chan bool,
+	queueCreator architecture.PriorityQueueCreator,
 ) {
 	go func() {
 		// create the tube
-		tube := architecture.NewTube(name, func() architecture.PriorityQueue {
-			// plug backends here
-			return &backend.MinHeap{}
-		})
+		tube := architecture.NewTube(name, queueCreator)
 		ticker := time.NewTicker(architecture.QUEUE_FREQUENCY)
 		for {
 			select {

--- a/operation/tube_register.go
+++ b/operation/tube_register.go
@@ -13,6 +13,7 @@ type TubeRegister struct {
 	useTubeConnectionReceiver      chan chan architecture.Command
 	watchedTubeConnectionsReceiver chan chan architecture.Command
 	stop                           chan bool
+	queueCreator                   architecture.PriorityQueueCreator
 }
 
 func (tr *TubeRegister) init() {
@@ -51,7 +52,7 @@ func (tr *TubeRegister) createTubeHandler(
 	chan architecture.Command, chan bool) {
 	tubeChannel := make(chan architecture.Command)
 	stop := make(chan bool)
-	NewTubeHandler(name, tubeChannel, watchedTubeConnectionsReceiver, stop)
+	NewTubeHandler(name, tubeChannel, watchedTubeConnectionsReceiver, stop, tr.queueCreator)
 	return tubeChannel, stop
 }
 
@@ -60,6 +61,7 @@ func NewTubeRegister(
 	useTubeConnectionReceiver chan chan architecture.Command,
 	watchedTubeConnectionsReceiver chan chan architecture.Command,
 	stop chan bool,
+	queueCreator architecture.PriorityQueueCreator,
 ) {
 	// store the tube stop signalling channels
 	tubeStopChannels := make(map[string]chan bool)
@@ -72,6 +74,7 @@ func NewTubeRegister(
 		useTubeConnectionReceiver,
 		watchedTubeConnectionsReceiver,
 		stop,
+		queueCreator,
 	}
 	go tubeRegister.init()
 }


### PR DESCRIPTION
Prior to this refactoring, a hard-coded `PriorityQueueCreator` in `tube_handler.go` only allowed `MinHeap`s to be used as a backend for beanstalkg.

This commit allows the user to choose their preferred backend, when available.

When a user-specified backend is unavailable, beanstalkg chooses to fallback to `MinHeap` instead of failing.

The new logic in `config.go` to choose the right `PriorityQueueCreator` probably belongs in the `backend` package, so I'll handle that in the morning.